### PR TITLE
feat(nix): add flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,35 @@ To get started with Falkor, follow these steps:
 
 - `VITE_RD_CLIENT_ID`: Open source app RD client ID found in the Real Debrid documentation (https://api.real-debrid.com/)
 
+### NixOS Flakes
+
+```nix
+# flake.nix
+
+{
+  inputs.falkor.url = "github:Team-Falkor/app";
+  # ...
+
+  outputs = {nixpkgs, falkor, ...} @ inputs: {
+    nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+      specialArgs = { inherit inputs; }; # this is the important part
+      modules = [
+        ./configuration.nix
+      ];
+    };
+  }
+}
+
+# configuration.nix
+
+{inputs, pkgs, ...}: {
+  environment.systemPackages = with pkgs; [
+    inputs.falkor.packages.${pkgs.system}.default
+    # ...
+  ];
+}
+```
+
 ## Contributing
 
 We welcome contributions to Falkor! If you are looking for ways to contribute, here are some options:

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Electron-based gaming hub";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      pkgsFor = nixpkgs.legacyPackages;
+      systems = [ "x86_64-linux" ];
+    in
+    {
+      packages = forAllSystems (system: {
+        default =
+          with pkgsFor.${system};
+          stdenvNoCC.mkDerivation (finalAttrs: {
+            pname = "falkor";
+            version = "0.0.92";
+
+            src = fetchurl {
+              url = "https://github.com/Team-Falkor/app/releases/download/v${finalAttrs.version}/falkor.deb";
+              hash = "sha256-yDpYu2ehrRQuD29jcyTQla2R2IT1zfBDeWDDRnmqc8Y=";
+            };
+
+            unpackPhase = ''
+              runHook preUnpack
+              dpkg -x $src ./
+              runHook postUnpack
+            '';
+
+            nativeBuildInputs = [
+              makeWrapper
+              dpkg
+            ];
+
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p $out/bin
+              mv usr/share $out/share
+              sed -i "s|Exec=.*|Exec=$out/bin/falkor|" $out/share/applications/*.desktop
+              mv opt/falkor $out/opt
+              makeWrapper ${lib.getExe electron} $out/bin/falkor \
+                --argv0 "falkor" \
+                --add-flags "$out/opt/resources/app.asar" \
+
+              runHook postInstall
+            '';
+          });
+      });
+    };
+}


### PR DESCRIPTION
This PR provides flake support for nix package manager users. The README includes instructions on how to use this for your configuration.

Closes #10.