### PR TITLE
feat: implement cached indicator w/ torbox

### DIFF
--- a/electron/api/routers/torbox/torrents.ts
+++ b/electron/api/routers/torbox/torrents.ts
@@ -1,0 +1,26 @@
+import { publicProcedure, router } from "@backend/api/trpc";
+import { getTorBoxTorrentsInstance } from "@backend/handlers/api-wrappers/torbox/services/torrents";
+import { z } from "zod";
+
+export const torBoxTorrentsRouter = router({
+	instantAvailability: publicProcedure
+		.input(
+			z.object({
+				apiKey: z.string(),
+				hashes: z.array(z.string()),
+			}),
+		)
+		.mutation(async ({ input }) => {
+			try {
+				const torrentsService = getTorBoxTorrentsInstance(input.apiKey);
+				const result = await torrentsService.instantAvailability(input.hashes);
+				return result ?? [];
+			} catch (error) {
+				throw new Error(
+					error instanceof Error
+						? error.message
+						: "Failed to check availability",
+				);
+			}
+		}),
+});

--- a/electron/api/trpc/root.ts
+++ b/electron/api/trpc/root.ts
@@ -13,6 +13,7 @@ import { communityProvidersRouter } from "../routers/plugins/providers/community
 import { protonDbRouter } from "../routers/protondb";
 import { realDebridAuthRouter } from "../routers/real-debrid/auth";
 import { torBoxAuthRouter } from "../routers/torbox/auth";
+import { torBoxTorrentsRouter } from "../routers/torbox/torrents";
 import { settingsRouter } from "../routers/settings";
 import { steamRouter } from "../routers/steam";
 import { router } from ".";
@@ -37,7 +38,8 @@ export const appRouter = router({
 		auth: realDebridAuthRouter,
 	},
 	torbox: {
-		auth: torBoxAuthRouter, 
+		auth: torBoxAuthRouter,
+		torrents: torBoxTorrentsRouter,
 	},
 	app: appFunctionsRouter,
 	steam: steamRouter,

--- a/electron/handlers/api-wrappers/torbox/index.ts
+++ b/electron/handlers/api-wrappers/torbox/index.ts
@@ -2,97 +2,75 @@ import { getInfoHashFromMagnet } from "@backend/utils/utils";
 import { Torrents } from "./services/torrents";
 import { User } from "./services/user";
 import { WebDownloads } from "./services/webDownloads";
-import { toast } from "sonner";
 import type { TorBoxTorrentInfoResult } from "@/@types/accounts";
 
 class TorBoxClient {
-  private static instance: TorBoxClient | null = null;
-  private readonly apiKey: string;
+	private static instance: TorBoxClient | null = null;
+	private readonly apiKey: string;
 
-  public readonly user: User;
-  public readonly torrents: Torrents;
-  public readonly webDownloads: WebDownloads;
+	public readonly user: User;
+	public readonly torrents: Torrents;
+	public readonly webDownloads: WebDownloads;
 
-  private constructor(apiKey: string) {
-    if (!apiKey) {
-      throw new Error(
-        "Access token not provided. Please provide a valid access token."
-      );
-    }
-    this.apiKey = apiKey;
-    this.user = new User(apiKey);
-    this.torrents = new Torrents(apiKey);
-    this.webDownloads = new WebDownloads(apiKey);
-    console.log("TorBoxClient initialized");
-  }
+	private constructor(apiKey: string) {
+		if (!apiKey) {
+			throw new Error(
+				"Access token not provided. Please provide a valid access token.",
+			);
+		}
+		this.apiKey = apiKey;
+		this.user = new User(apiKey);
+		this.torrents = new Torrents(apiKey);
+		this.webDownloads = new WebDownloads(apiKey);
+	}
 
-  public static getInstance(apiKey: string): TorBoxClient {
-    if (TorBoxClient.instance && TorBoxClient.instance.apiKey !== apiKey) {
-      throw new Error(
-        "A different instance with a conflicting access token already exists."
-      );
-    }
-    if (!TorBoxClient.instance) {
-      TorBoxClient.instance = new TorBoxClient(apiKey);
-    }
-    return TorBoxClient.instance;
-  }
+	public static getInstance(apiKey: string): TorBoxClient {
+		if (TorBoxClient.instance && TorBoxClient.instance.apiKey !== apiKey) {
+			throw new Error(
+				"A different instance with a conflicting access token already exists.",
+			);
+		}
+		if (!TorBoxClient.instance) {
+			TorBoxClient.instance = new TorBoxClient(apiKey);
+		}
+		return TorBoxClient.instance;
+	}
 
-  private async getOrCreateTorrent(
-    magnetLink: string
-  ): Promise<TorBoxTorrentInfoResult> {
-    const infoHash = getInfoHashFromMagnet(magnetLink);
+	private async getOrCreateTorrent(
+		magnetLink: string,
+	): Promise<TorBoxTorrentInfoResult> {
+		const infoHash = getInfoHashFromMagnet(magnetLink);
 
-    if (!infoHash) {
-      throw new Error("Invalid magnet provided.");
-    }
+		if (!infoHash) {
+			throw new Error("Invalid magnet provided.");
+		}
 
-    let foundTorrent = await this.torrents.getHashInfo(infoHash);
-    if (foundTorrent) {
-      return foundTorrent;
-    }
+		let foundTorrent = await this.torrents.getHashInfo(infoHash);
+		if (foundTorrent) {
+			return foundTorrent;
+		}
 
-    const addedTorrent = await this.torrents.addMagnet(magnetLink);
-    if (!addedTorrent?.hash) {
-      throw new Error("Failed to add torrent. No Hash returned.");
-    }
+		const addedTorrent = await this.torrents.addMagnet(magnetLink);
+		if (!addedTorrent?.hash) {
+			throw new Error("Failed to add torrent. No Hash returned.");
+		}
 
-    foundTorrent = await this.torrents.getHashInfo(infoHash);
-    if (!foundTorrent) {
-      throw new Error("Failed to retrieve added torrent info.");
-    }
-    return foundTorrent;
-  }
+		foundTorrent = await this.torrents.getHashInfo(infoHash);
+		if (!foundTorrent) {
+			throw new Error("Failed to retrieve added torrent info.");
+		}
+		return foundTorrent;
+	}
 
-  public async downloadTorrentFromMagnet(
-    magnetLink: string
-  ): Promise<TorBoxTorrentInfoResult> {
-    const torrentInfo = await this.getOrCreateTorrent(
-      decodeURIComponent(magnetLink)
-    );
+	public async downloadTorrentFromMagnet(
+		magnetLink: string,
+	): Promise<TorBoxTorrentInfoResult> {
+		const torrentInfo = await this.getOrCreateTorrent(
+			decodeURIComponent(magnetLink),
+		);
 
-    return torrentInfo;
-  }
-
-  public async downloadFromFileHost(
-    _url: string,
-    _password?: string
-  ): Promise<string> {
-    throw new Error("TorBox currently does not support file host downloads.");
-  }
-  public async getDownloadName(url: string, type: string): Promise<string> {
-    if (type != "ddl") {
-      const torrentHash = getInfoHashFromMagnet(url);
-      if (torrentHash) {
-        const torrentInfo = await this.torrents.getHashInfo(torrentHash);
-
-        if (torrentInfo) {
-          return `${torrentInfo.name}`;
-        }
-      }
-    }
-    return "";
-  }
+		return torrentInfo;
+	}
 }
 
 export { TorBoxClient };

--- a/electron/handlers/api-wrappers/torbox/index.ts
+++ b/electron/handlers/api-wrappers/torbox/index.ts
@@ -1,8 +1,8 @@
+import type { TorBoxTorrentInfoResult } from "@/@types/accounts";
 import { getInfoHashFromMagnet } from "@backend/utils/utils";
 import { Torrents } from "./services/torrents";
 import { User } from "./services/user";
 import { WebDownloads } from "./services/webDownloads";
-import type { TorBoxTorrentInfoResult } from "@/@types/accounts";
 
 class TorBoxClient {
 	private static instance: TorBoxClient | null = null;

--- a/electron/handlers/api-wrappers/torbox/services/api.ts
+++ b/electron/handlers/api-wrappers/torbox/services/api.ts
@@ -1,31 +1,30 @@
 export class TorBoxAPI {
-  private baseUrl: string;
-  public accessToken: string;
+	private baseUrl: string;
+	public accessToken: string;
 
-  constructor(accessToken: string) {
-    if (!accessToken) throw new Error("No access token provided");
-    this.accessToken = accessToken;
+	constructor(accessToken: string) {
+		if (!accessToken) throw new Error("No access token provided");
+		this.accessToken = accessToken;
 
-    this.baseUrl = "https://api.torbox.app/v1/api/";
-  }
+		this.baseUrl = "https://api.torbox.app/v1/api/";
+	}
 
-  async makeRequest<T>(
-    endpoint: string,
-    method: "GET" | "POST" | "HEAD" = "GET",
-    authRequired = true,
-    body?: BodyInit,
-    headersInit?: HeadersInit
-  ): Promise<T> {
-    const url = `${this.baseUrl}${endpoint}`;
+	async makeRequest<T>(
+		endpoint: string,
+		method: "GET" | "POST" | "HEAD" = "GET",
+		authRequired = true,
+		body?: BodyInit,
+		headersInit?: HeadersInit,
+	): Promise<T> {
+		const url = `${this.baseUrl}${endpoint}`;
+		const headers: HeadersInit = {
+			...(authRequired ? { Authorization: `Bearer ${this.accessToken}` } : {}),
+			...headersInit,
+		};
 
-    const headers: HeadersInit = {
-      ...(authRequired ? { Authorization: `Bearer ${this.accessToken}` } : {}),
-      ...headersInit,
-    };
-
-    const res = await fetch(url, { method, headers, body });
-    const text = await res.text();
-    if (!text) throw new Error("Torbox: No data returned from API");
-    return JSON.parse(text);
-  }
+		const res = await fetch(url, { method, headers, body });
+		const text = await res.text();
+		if (!text) throw new Error("Torbox: No data returned from API");
+		return JSON.parse(text);
+	}
 }

--- a/electron/handlers/api-wrappers/torbox/services/torrents.ts
+++ b/electron/handlers/api-wrappers/torbox/services/torrents.ts
@@ -72,21 +72,6 @@ export class Torrents extends TorBoxAPI {
 		return torrents;
 	}
 
-	public async getAllTorrents(): Promise<TorBoxTorrentInfoResult[]> {
-		const torrents: TorBoxTorrentInfoResult[] = [];
-
-		const currentTorrents = await this.getCurrent();
-		if (currentTorrents?.length) {
-			torrents.push(...currentTorrents);
-		}
-
-		const queuedTorrents = await this.getQueued();
-		if (queuedTorrents?.length) {
-			torrents.push(...queuedTorrents);
-		}
-		return torrents;
-	}
-
 	public async instantAvailability(
 		torrentHashes: string[],
 	): Promise<TorBoxAvailableTorrent[] | null> {
@@ -134,24 +119,6 @@ export class Torrents extends TorBoxAPI {
 		}
 
 		return null;
-	}
-
-	public async delete(torrentHash: string): Promise<boolean> {
-		const torrent = await this.getHashInfo(torrentHash);
-		if (!torrent) {
-			return false;
-		}
-		const body = new URLSearchParams({
-			torrent_id: torrent.id.toString(),
-			operation: "delete",
-		});
-		await this.makeRequest(
-			"torrents/controltorrent",
-			"POST",
-			true,
-			body.toString(),
-		);
-		return true;
 	}
 }
 

--- a/electron/handlers/api-wrappers/torbox/services/torrents.ts
+++ b/electron/handlers/api-wrappers/torbox/services/torrents.ts
@@ -1,5 +1,4 @@
 import "@/@types/accounts/torbox";
-import { TorBoxAPI } from "./api";
 import {
 	type TorBoxAddTorrent,
 	type TorBoxAvailableTorrent,
@@ -8,6 +7,7 @@ import {
 	type TorBoxResponse,
 	type TorBoxTorrentInfoResult,
 } from "@/@types/accounts/torbox";
+import { TorBoxAPI } from "./api";
 
 export class Torrents extends TorBoxAPI {
 	public async getHashInfo(

--- a/electron/handlers/api-wrappers/torbox/services/torrents.ts
+++ b/electron/handlers/api-wrappers/torbox/services/torrents.ts
@@ -1,158 +1,165 @@
 import "@/@types/accounts/torbox";
 import { TorBoxAPI } from "./api";
 import {
-  type TorBoxAddTorrent,
-  type TorBoxAvailableTorrent,
-  TorBoxDefaultInfo,
-  type TorBoxQueuedDownload,
-  type TorBoxResponse,
-  type TorBoxTorrentInfoResult,
+	type TorBoxAddTorrent,
+	type TorBoxAvailableTorrent,
+	TorBoxDefaultInfo,
+	type TorBoxQueuedDownload,
+	type TorBoxResponse,
+	type TorBoxTorrentInfoResult,
 } from "@/@types/accounts/torbox";
 
 export class Torrents extends TorBoxAPI {
-  public async getHashInfo(
-    hash: string
-  ): Promise<TorBoxTorrentInfoResult | null> {
-    const currentTorrents = await this.getCurrent();
+	public async getHashInfo(
+		hash: string,
+	): Promise<TorBoxTorrentInfoResult | null> {
+		const currentTorrents = await this.getCurrent();
 
-    if (currentTorrents?.length) {
-      const foundInCurrent = currentTorrents.find(
-        (torrent) => torrent.hash.toLowerCase() === hash.toLowerCase()
-      );
-      if (foundInCurrent) return foundInCurrent;
-    }
+		if (currentTorrents?.length) {
+			const foundInCurrent = currentTorrents.find(
+				(torrent) => torrent.hash.toLowerCase() === hash.toLowerCase(),
+			);
+			if (foundInCurrent) return foundInCurrent;
+		}
 
-    const queuedTorrents = await this.getQueued();
+		const queuedTorrents = await this.getQueued();
 
-    if (queuedTorrents?.length) {
-      const foundInQueued = queuedTorrents.find(
-        (torrent) => torrent.hash.toLowerCase() === hash.toLowerCase()
-      );
-      if (foundInQueued) return foundInQueued;
-    }
+		if (queuedTorrents?.length) {
+			const foundInQueued = queuedTorrents.find(
+				(torrent) => torrent.hash.toLowerCase() === hash.toLowerCase(),
+			);
+			if (foundInQueued) return foundInQueued;
+		}
 
-    return null;
-  }
+		return null;
+	}
 
-  public async getCurrent(): Promise<TorBoxTorrentInfoResult[] | null> {
-    const response = await this.makeRequest<
-      TorBoxResponse<TorBoxTorrentInfoResult[]>
-    >("torrents/mylist?bypass_cache=true", "GET", true);
+	public async getCurrent(): Promise<TorBoxTorrentInfoResult[] | null> {
+		const response = await this.makeRequest<
+			TorBoxResponse<TorBoxTorrentInfoResult[]>
+		>("torrents/mylist?bypass_cache=true", "GET", true);
 
-    return response?.data || null;
-  }
+		return response?.data || null;
+	}
 
-  public async getQueued(): Promise<TorBoxTorrentInfoResult[] | null> {
-    const response = await this.makeRequest<
-      TorBoxResponse<TorBoxQueuedDownload[]>
-    >("queued/getqueued?type=torrent", "GET", true);
+	public async getQueued(): Promise<TorBoxTorrentInfoResult[] | null> {
+		const response = await this.makeRequest<
+			TorBoxResponse<TorBoxQueuedDownload[]>
+		>("queued/getqueued?type=torrent", "GET", true);
 
-    if (!response || !response.data) {
-      return null;
-    }
+		if (!response || !response.data) {
+			return null;
+		}
 
-    const torrents: TorBoxTorrentInfoResult[] = response.data.map(
-      (torrent) => ({
-        ...TorBoxDefaultInfo,
-        id: torrent.id,
-        hash: torrent.hash,
-        name: torrent.name,
-        magnet: torrent.magnet,
-        createdAt: torrent.created_at,
-        downloadState: "queued",
-        torrentFile: !!torrent.torrent_file,
-        progress: 0.0,
-        files: [],
-        downloadSpeed: 0,
-        seeds: 0,
-        updatedAt: torrent.created_at,
-      })
-    );
+		const torrents: TorBoxTorrentInfoResult[] = response.data.map(
+			(torrent) => ({
+				...TorBoxDefaultInfo,
+				id: torrent.id,
+				hash: torrent.hash,
+				name: torrent.name,
+				magnet: torrent.magnet,
+				createdAt: torrent.created_at,
+				downloadState: "queued",
+				torrentFile: !!torrent.torrent_file,
+				progress: 0.0,
+				files: [],
+				downloadSpeed: 0,
+				seeds: 0,
+				updatedAt: torrent.created_at,
+			}),
+		);
 
-    return torrents;
-  }
+		return torrents;
+	}
 
-  public async getAllTorrents(): Promise<TorBoxTorrentInfoResult[]> {
-    const torrents: TorBoxTorrentInfoResult[] = [];
+	public async getAllTorrents(): Promise<TorBoxTorrentInfoResult[]> {
+		const torrents: TorBoxTorrentInfoResult[] = [];
 
-    const currentTorrents = await this.getCurrent();
-    if (currentTorrents?.length) {
-      torrents.push(...currentTorrents);
-    }
+		const currentTorrents = await this.getCurrent();
+		if (currentTorrents?.length) {
+			torrents.push(...currentTorrents);
+		}
 
-    const queuedTorrents = await this.getQueued();
-    if (queuedTorrents?.length) {
-      torrents.push(...queuedTorrents);
-    }
-    return torrents;
-  }
+		const queuedTorrents = await this.getQueued();
+		if (queuedTorrents?.length) {
+			torrents.push(...queuedTorrents);
+		}
+		return torrents;
+	}
 
-  public async instantAvailability(
-    torrentHash: string
-  ): Promise<TorBoxAvailableTorrent | null> {
-    const response = await this.makeRequest<
-      TorBoxResponse<TorBoxAvailableTorrent[] | null>
-    >(
-      `torrents/checkcached?hash=${torrentHash}&format=list&list_files=true`,
-      "GET",
-      false
-    );
+	public async instantAvailability(
+		torrentHashes: string[],
+	): Promise<TorBoxAvailableTorrent[] | null> {
+		const hashParams = torrentHashes.map((h) => `hash=${h}`).join("&");
+		const url = `torrents/checkcached?format=list&list_files=false&${hashParams}`;
+		const response = await this.makeRequest<
+			TorBoxResponse<TorBoxAvailableTorrent[] | null>
+		>(url, "GET", true);
 
-    if (response.data && response.data.length > 0) {
-      return response.data[0];
-    }
+		if (response.data && response.data.length > 0) {
+			return response.data;
+		}
 
-    return null;
-  }
+		return null;
+	}
 
-  public async addMagnet(magnet: string): Promise<TorBoxAddTorrent | null> {
-    const body = new FormData();
-    body.append("magnet", magnet);
-    body.append("seed", "3");
-    body.append("zip", "false");
+	public async addMagnet(magnet: string): Promise<TorBoxAddTorrent | null> {
+		const body = new FormData();
+		body.append("magnet", magnet);
+		body.append("seed", "3");
+		body.append("zip", "false");
 
-    const response = await this.makeRequest<TorBoxResponse<TorBoxAddTorrent>>(
-      "torrents/createtorrent",
-      "POST",
-      true,
-      body
-    );
+		const response = await this.makeRequest<TorBoxResponse<TorBoxAddTorrent>>(
+			"torrents/createtorrent",
+			"POST",
+			true,
+			body,
+		);
 
-    if (response.data) {
-      return response.data;
-    }
-    return null;
-  }
+		if (response.data) {
+			return response.data;
+		}
+		return null;
+	}
 
-  public async getZipDL(torrentId: string): Promise<string | null> {
-    const response = await this.makeRequest<TorBoxResponse<string | null>>(
-      `torrents/requestdl?token=${this.accessToken}&torrent_id=${torrentId}&zip_link=true`,
-      "GET",
-      false
-    );
+	public async getZipDL(torrentId: string): Promise<string | null> {
+		const response = await this.makeRequest<TorBoxResponse<string | null>>(
+			`torrents/requestdl?token=${this.accessToken}&torrent_id=${torrentId}&zip_link=true`,
+			"GET",
+			false,
+		);
 
-    if (response.success && response.data) {
-      return response.data;
-    }
+		if (response.success && response.data) {
+			return response.data;
+		}
 
-    return null;
-  }
+		return null;
+	}
 
-  public async delete(torrentHash: string): Promise<boolean> {
-    const torrent = await this.getHashInfo(torrentHash);
-    if (!torrent) {
-      return false;
-    }
-    const body = new URLSearchParams({
-      torrent_id: torrent.id.toString(),
-      operation: "delete",
-    });
-    await this.makeRequest(
-      "torrents/controltorrent",
-      "POST",
-      true,
-      body.toString()
-    );
-    return true;
-  }
+	public async delete(torrentHash: string): Promise<boolean> {
+		const torrent = await this.getHashInfo(torrentHash);
+		if (!torrent) {
+			return false;
+		}
+		const body = new URLSearchParams({
+			torrent_id: torrent.id.toString(),
+			operation: "delete",
+		});
+		await this.makeRequest(
+			"torrents/controltorrent",
+			"POST",
+			true,
+			body.toString(),
+		);
+		return true;
+	}
 }
+
+let instance: Torrents | null = null;
+
+export const getTorBoxTorrentsInstance = (api_key: string): Torrents => {
+	if (!instance) {
+		instance = new Torrents(api_key);
+	}
+	return instance;
+};

--- a/electron/handlers/api-wrappers/torbox/services/user.ts
+++ b/electron/handlers/api-wrappers/torbox/services/user.ts
@@ -2,25 +2,24 @@ import type { TorBoxResponse, TorBoxUser } from "@/@types/accounts";
 import { TorBoxAPI } from "./api";
 
 export class User extends TorBoxAPI {
-
-  public async getUserInfo(): Promise<TorBoxUser | null> {
-    const response = await this.makeRequest<TorBoxResponse<TorBoxUser>>(
-      "user/me?settings=false",
-      "GET",
-      true
-    );
-    if (response.success && response.data) {
-      return response.data;
-    }
-    return null;
-  }
+	public async getUserInfo(): Promise<TorBoxUser | null> {
+		const response = await this.makeRequest<TorBoxResponse<TorBoxUser>>(
+			"user/me?settings=false",
+			"GET",
+			true,
+		);
+		if (response.success && response.data) {
+			return response.data;
+		}
+		return null;
+	}
 }
 
 let instance: User | null = null;
 
 export const getTorBoxUserInstance = (api_key: string): User => {
-  if (!instance) {
-    instance = new User(api_key);
-  }
-  return instance;
+	if (!instance) {
+		instance = new User(api_key);
+	}
+	return instance;
 };

--- a/electron/handlers/api-wrappers/torbox/services/webDownloads.ts
+++ b/electron/handlers/api-wrappers/torbox/services/webDownloads.ts
@@ -3,27 +3,25 @@ import { TorBoxAPI } from "./api";
 import type {
 	TorBoxResponse,
 	TorBoxWebDownloadItem,
-	TorBoxAddWebDownload
+	TorBoxAddWebDownload,
 } from "@/@types/accounts/torbox";
 
 export class WebDownloads extends TorBoxAPI {
-
 	public async createWebDownload(link: string): Promise<TorBoxWebDownloadItem> {
 		const body = new FormData();
 		body.append("link", link);
 
-		const response = await this.makeRequest<TorBoxResponse<TorBoxAddWebDownload>>(
-			"webdl/createwebdownload",
-			"POST",
-			true,
-			body
-		);
+		const response = await this.makeRequest<
+			TorBoxResponse<TorBoxAddWebDownload>
+		>("webdl/createwebdownload", "POST", true, body);
 
 		if (response.data) {
-			const info = await this.makeRequest<TorBoxResponse<TorBoxWebDownloadItem>>(
+			const info = await this.makeRequest<
+				TorBoxResponse<TorBoxWebDownloadItem>
+			>(
 				`webdl/mylist?id=${response.data.webdownload_id}&bypass_cache=true`,
 				"GET",
-				true
+				true,
 			);
 
 			if (info.success && info.data) {
@@ -35,11 +33,11 @@ export class WebDownloads extends TorBoxAPI {
 	}
 
 	public async getWebDownloadDownload(id: number): Promise<string> {
-		const stringid = `webdl/requestdl?token=${this.accessToken}&web_id=${id.toString()}&zip_link=true`
+		const stringid = `webdl/requestdl?token=${this.accessToken}&web_id=${id.toString()}&zip_link=true`;
 		const response = await this.makeRequest<TorBoxResponse<string>>(
 			stringid,
 			"GET",
-			false
+			false,
 		);
 
 		if (response.success && response.data) {
@@ -48,5 +46,4 @@ export class WebDownloads extends TorBoxAPI {
 
 		throw new Error("TorBox: Failed to unrestrict web download");
 	}
-
 }

--- a/electron/handlers/api-wrappers/torbox/services/webDownloads.ts
+++ b/electron/handlers/api-wrappers/torbox/services/webDownloads.ts
@@ -1,10 +1,10 @@
 import "@/@types/accounts/torbox";
-import { TorBoxAPI } from "./api";
 import type {
+	TorBoxAddWebDownload,
 	TorBoxResponse,
 	TorBoxWebDownloadItem,
-	TorBoxAddWebDownload,
 } from "@/@types/accounts/torbox";
+import { TorBoxAPI } from "./api";
 
 export class WebDownloads extends TorBoxAPI {
 	public async createWebDownload(link: string): Promise<TorBoxWebDownloadItem> {

--- a/src/components/cards/sourcecard/downloadSourceContent.tsx
+++ b/src/components/cards/sourcecard/downloadSourceContent.tsx
@@ -1,5 +1,13 @@
 import type { PluginSearchResponse } from "@team-falkor/shared-types";
-import { Activity, CloudDownload, Save, Users } from "lucide-react";
+import {
+	Activity,
+	CheckCircle,
+	CloudDownload,
+	Loader,
+	Save,
+	Users,
+	XCircle,
+} from "lucide-react";
 import type { DownloadgameData } from "@/@types";
 import { useDownloadActions } from "@/hooks/use-download-actions";
 import { useLanguageContext } from "@/i18n/I18N";
@@ -13,6 +21,8 @@ type DownloadSourceContentProps = {
 	pluginId?: string;
 	game_data?: DownloadgameData;
 	multiple_choice?: boolean;
+	cacheStatus?: "checking" | "cached" | "not_cached" | "unsupported";
+	isChecking?: boolean;
 };
 
 export const DownloadSourceContent = ({
@@ -20,6 +30,8 @@ export const DownloadSourceContent = ({
 	pluginId,
 	game_data,
 	multiple_choice,
+	cacheStatus,
+	isChecking,
 }: DownloadSourceContentProps) => {
 	const { t } = useLanguageContext();
 	const { addDownload } = useDownloadActions();
@@ -47,6 +59,31 @@ export const DownloadSourceContent = ({
 		}
 	};
 
+	const getCacheContent = () => {
+		switch (cacheStatus) {
+			case "checking":
+				return {
+					icon: Loader,
+					text: "Checking...",
+					iconClassName: "animate-spin",
+				};
+			case "cached":
+				return {
+					icon: CheckCircle,
+					text: "Cached",
+					iconClassName: "text-success",
+				};
+			case "not_cached":
+				return {
+					icon: XCircle,
+					text: "Not Cached",
+					iconClassName: "text-destructive",
+				};
+		}
+	};
+
+	const cacheContent = getCacheContent();
+
 	return (
 		<div className="flex size-full flex-col justify-between overflow-hidden">
 			<div className="flex size-full flex-col justify-between overflow-hidden">
@@ -67,16 +104,24 @@ export const DownloadSourceContent = ({
 								<StatPill
 									key={statKey}
 									icon={getIconForStat(statKey)}
-									value={stats[statKey]}
+									value={stats[statKey] ?? ""}
 								/>
 							);
 						})}
+						{cacheStatus && cacheStatus !== "unsupported" && cacheContent && (
+							<StatPill
+								icon={cacheContent.icon}
+								value={cacheContent.text}
+								iconClassName={cacheContent.iconClassName}
+							/>
+						)}
 					</div>
 				)}
 			</div>
 			<Button
 				className="w-full items-center gap-3 rounded-full font-bold capitalize"
 				variant="success"
+				disabled={isChecking}
 				onClick={() => {
 					addDownload({
 						pluginId: pluginId,
@@ -89,7 +134,11 @@ export const DownloadSourceContent = ({
 					});
 				}}
 			>
-				<CloudDownload size={18} fill="currentColor" className="shrink-0" />
+				{cacheStatus === "checking" ? (
+					<Loader className="size-4 animate-spin" />
+				) : (
+					<CloudDownload size={18} fill="currentColor" className="shrink-0" />
+				)}
 				<P className="max-w-full truncate capitalize">
 					{source?.uploader ?? t("download")}
 				</P>

--- a/src/components/cards/sourcecard/downloadSourceContent.tsx
+++ b/src/components/cards/sourcecard/downloadSourceContent.tsx
@@ -104,7 +104,7 @@ export const DownloadSourceContent = ({
 								<StatPill
 									key={statKey}
 									icon={getIconForStat(statKey)}
-									value={stats[statKey] ?? ""}
+									value={stats[statKey]?.toString()}
 								/>
 							);
 						})}

--- a/src/components/cards/sourcecard/index.tsx
+++ b/src/components/cards/sourcecard/index.tsx
@@ -16,11 +16,11 @@ type SourceCardProps = {
 	game_data?: DownloadgameData;
 	multiple_choice?: boolean;
 	slug?: string;
+	cacheStatus?: "checking" | "cached" | "not_cached" | "unsupported";
+	isChecking?: boolean;
 };
 
 export const SourceCard = ({ source, ...props }: SourceCardProps) => {
-	// const { settings } = useSettings();
-
 	const isDeal = (item: SourceCardProps["source"]): item is Deal =>
 		"price" in item && "shop" in item;
 
@@ -54,6 +54,8 @@ export const SourceCard = ({ source, ...props }: SourceCardProps) => {
 						pluginId={props.pluginId}
 						game_data={props.game_data}
 						multiple_choice={props.multiple_choice}
+						cacheStatus={props.cacheStatus}
+						isChecking={props.isChecking}
 					/>
 				)}
 			</div>

--- a/src/components/cards/sourcecard/statPill.tsx
+++ b/src/components/cards/sourcecard/statPill.tsx
@@ -1,21 +1,28 @@
 import type { ElementType, ReactNode } from "react";
 
+import { cn } from "@/lib";
 import { TypographySmall } from "../../ui/typography";
 
 interface StatPillProps {
 	icon: ElementType;
 	value: ReactNode;
 	isVisible?: boolean;
+	iconClassName?: string;
 }
 
-const StatPill = ({ icon: Icon, value, isVisible = true }: StatPillProps) => {
+const StatPill = ({
+	icon: Icon,
+	value,
+	isVisible = true,
+	iconClassName,
+}: StatPillProps) => {
 	if (!isVisible) {
 		return null;
 	}
 
 	return (
 		<div className="flex items-center gap-2 rounded-full bg-muted px-2 py-1 shadow-sm">
-			<Icon className="size-3" />
+			<Icon className={cn("size-3", iconClassName)} />
 			<TypographySmall className="flex-1 text-xs">{value}</TypographySmall>
 		</div>
 	);

--- a/src/hooks/useCacheStatuses.ts
+++ b/src/hooks/useCacheStatuses.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from "react";
+import { trpc } from "@/lib";
+import { getInfoHashFromMagnet } from "@/lib/utils";
+import type { PluginSearchResponse } from "@team-falkor/shared-types";
+
+export type CacheStatus = "checking" | "cached" | "not_cached" | "unsupported";
+
+export interface UseCacheStatusesResult {
+	cacheStatuses: Record<string, CacheStatus>;
+	hasAnyAccount: boolean;
+	isChecking: boolean;
+}
+
+export function useCacheStatuses(
+	sources: PluginSearchResponse[],
+	torboxAccount?: { accessToken: string },
+): UseCacheStatusesResult {
+	const [cacheStatuses, setCacheStatuses] = useState<
+		Record<string, CacheStatus>
+	>({});
+	const [hasChecked, setHasChecked] = useState(false);
+
+	const availabilityMutation =
+		trpc.torbox.torrents.instantAvailability.useMutation();
+
+	const checkAvailability = useCallback(
+		async (hashes: string[], apiKey: string, magnetUrls: string[]) => {
+			try {
+				const result = await availabilityMutation.mutateAsync({
+					apiKey,
+					hashes,
+				});
+				const newStatuses: Record<string, "cached" | "not_cached"> = {};
+				magnetUrls.forEach((url) => {
+					const hash = getInfoHashFromMagnet(url);
+					const isCached =
+						!!hash &&
+						result.some((t) => t.hash.toLowerCase() === hash.toLowerCase());
+					newStatuses[url] = isCached ? "cached" : "not_cached";
+				});
+				setCacheStatuses((prev) => ({ ...prev, ...newStatuses }));
+			} catch {
+				const errorStatuses: Record<string, "unsupported"> = {};
+				magnetUrls.forEach((url) => {
+					errorStatuses[url] = "unsupported";
+				});
+				setCacheStatuses((prev) => ({ ...prev, ...errorStatuses }));
+			}
+		},
+		[availabilityMutation],
+	);
+
+	useEffect(() => {
+		if (!sources.length || hasChecked) return;
+
+		const allUrls = sources.map((s) => s.return).filter(Boolean) as string[];
+		if (!torboxAccount) {
+			const unsupported: Record<string, "unsupported"> = {};
+			allUrls.forEach((url) => {
+				unsupported[url] = "unsupported";
+			});
+			setCacheStatuses(unsupported);
+			return;
+		}
+
+		const magnetUrls = allUrls.filter((u) => u.startsWith("magnet:"));
+		const nonMagnet = allUrls.filter((u) => !u.startsWith("magnet:"));
+		if (nonMagnet.length) {
+			const unsupported: Record<string, "unsupported"> = {};
+			nonMagnet.forEach((url) => {
+				unsupported[url] = "unsupported";
+			});
+			setCacheStatuses((prev) => ({ ...prev, ...unsupported }));
+		}
+
+		if (magnetUrls.length && torboxAccount.accessToken) {
+			const initial: Record<string, "checking"> = {};
+			magnetUrls.forEach((url) => {
+				initial[url] = "checking";
+			});
+			setCacheStatuses(initial);
+			const hashes = magnetUrls
+				.map((u) => getInfoHashFromMagnet(u))
+				.filter(Boolean) as string[];
+			checkAvailability(hashes, torboxAccount.accessToken, magnetUrls);
+			setHasChecked(true);
+		}
+	}, [sources, torboxAccount, checkAvailability, hasChecked]);
+
+	const hasAnyAccount = Boolean(torboxAccount);
+	const isChecking = Object.values(cacheStatuses).some((s) => s === "checking");
+
+	return { cacheStatuses, hasAnyAccount, isChecking };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -136,3 +136,8 @@ export function formatPlaytime(totalMilliseconds: number): string {
 
 	return parts.length > 0 ? parts.join(" ") : "0s";
 }
+
+export function getInfoHashFromMagnet(magnetUrl: string): string | null {
+	const match = magnetUrl.match(/xt=urn:btih:([a-fA-F0-9]{40,})/);
+	return match ? match[1] : null;
+}


### PR DESCRIPTION
## ✨ Description

Implements a statpill on each download card that indicates whether it is cached or not. Currently only supports checking for torrents.

Also dealt with some biomejs formatting and sorting of imports and exports in torbox wrapper, as well as removing unused functions inside the wrapper.

## 🎯 Type of Change

<!--
Please select the type of change that this PR introduces by placing an "x" in the corresponding brackets.
You can select multiple options if applicable.
-->

- [ ] Bug fix (resolves an issue)
- [x] New Feature (adds new functionality)
- [x] Refactor (improves code structure/readability without changing behavior)
- [ ] Documentation update (improving comments, README, wiki, etc.)
- [ ] Performance improvement (optimizes existing functionality)
- [ ] Chore (maintenance tasks, dependency updates, build process, etc.)
- [ ] Other (please specify):

## 🧪 How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Also, list any relevant configuration details.
-->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps below)
- [ ] No testing required (e.g., documentation changes)

**Test Steps (for manual testing):**
1. Open game in home screen with sources installed and a TorBox account connected
2. Wait for a non-itad source to load
3. Check to see if the cached indicator is working

## 📸 Screenshots / Demos (if applicable)

![image](https://github.com/user-attachments/assets/63c2212d-d07d-4ffe-8df2-e111df8f29e1)

## 💥 Breaking Changes

<!--
Does this PR introduce any breaking changes that would require users to update their code or configuration?
If yes, please describe the impact and provide migration steps.
-->
- [ ] Yes
- [x] No

## ✅ Checklist

<!--
Please go through the following checklist and mark the applicable items with an "x".
-->
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.

